### PR TITLE
Add formula for tanzu-cli

### DIFF
--- a/tanzu-cli.rb
+++ b/tanzu-cli.rb
@@ -1,0 +1,37 @@
+# Copyright 2022 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+class TanzuCli < Formula
+  desc "The bare-bones Tanzu command-line tool"
+  homepage "https://github.com/vmware-tanzu/tanzu-framework"
+  version "0.25.0"
+  head "https://github.com/vmware-tanzu/tanzu-framework.git", branch: "main"
+
+  checksums = {
+    "darwin-amd64" => "71dc3eaecdaa8f9479ef3a4ac88ef9373d832104aefeed8f0252eb2be92f8403",
+    "linux-amd64"  => "c9967ea224a9b2cb0edd9a061a157e234b83ed4876757b1eada0f3025214e4b6",
+  }
+
+  # Switch this to "arm64" when it is supported by Framework builds
+  $arch = "amd64"
+  on_intel do
+    $arch = "amd64"
+  end
+
+  $os = "darwin"
+  on_linux do
+    $os = "linux"
+  end
+
+  url "https://github.com/vmware-tanzu/tanzu-framework/releases/download/v#{version}/tanzu-cli-#{$os}-#{$arch}.tar.gz"
+  sha256 checksums["#{$os}-#{$arch}"]
+
+  def install
+    bin.install "v#{version}/tanzu-core-#{$os}_#{$arch}" => "tanzu"
+  end
+
+  # Homebrew requires tests.
+#  test do
+#    assert_match("ceaa474", shell_output("#{bin}/tanzu version", 2))
+#  end
+end


### PR DESCRIPTION
## What this PR does / why we need it

Formula for tanzu-cli for both Mac and Linux

## Describe testing done for PR

Testing for Mac:
```
$ brew uninstall tanzu-cli
Error: No available formula with the name "tanzu-cli". Did you mean azure-cli?

$ which tanzu
tanzu not found

$ brew install --build-from-source $HOME/git/homebrew-tanzu/tanzu-cli.rb
Error: Failed to load cask: /Users/kmarc/git/homebrew-tanzu/tanzu-cli.rb
Cask 'tanzu-cli' is unreadable: wrong constant name #<Class:0x000000014ebff370>
Warning: Treating /Users/kmarc/git/homebrew-tanzu/tanzu-cli.rb as a formula.
==> Downloading https://github.com/vmware-tanzu/tanzu-framework/releases/download/v0.25.0/tanzu-cli-darwin-amd64.tar.gz
Already downloaded: /Users/kmarc/Library/Caches/Homebrew/downloads/242987483930c4631317e82f64032ab893e03d32e8540160d0c361158a6b5d3b--tanzu-cli-darwin-amd64.tar.gz
🍺  /opt/homebrew/Cellar/tanzu-cli/0.25.0: 3 files, 72.8MB, built in 4 seconds
==> Running `brew cleanup tanzu-cli`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).

$ which tanzu && tanzu version
/opt/homebrew/bin/tanzu
version: v0.25.0
buildDate: 2022-08-05
sha: 8db7108d
```

Testing for linux:
```
$ docker run -it --rm -v $HOME/git/homebrew-tanzu:/tmp/homebrew-tanzu homebrew/brew

linuxbrew@ebd11d3dea3a:~$ which tanzu

linuxbrew@ebd11d3dea3a:~$ brew install --build-from-source /tmp/homebrew-tanzu/tanzu-cli.rb
Running `brew update --auto-update`...
[..]
Error: Failed to load cask: /tmp/homebrew-tanzu/tanzu-cli.rb
Cask 'tanzu-cli' is unreadable: wrong constant name #<Class:0x00000000026a8fe0>
Warning: Treating /tmp/homebrew-tanzu/tanzu-cli.rb as a formula.
==> Downloading https://github.com/vmware-tanzu/tanzu-framework/releases/download/v0.25.0/tanzu-cli-linux-amd64.tar.gz
==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/380270062/b258af1d-772f-4c41-b722-4b7f43477e9
######################################################################## 100.0%
🍺  /home/linuxbrew/.linuxbrew/Cellar/tanzu-cli/0.25.0: 3 files, 63.5MB, built in 12 seconds
==> Running `brew cleanup tanzu-cli`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).

linuxbrew@ebd11d3dea3a:~$ which tanzu && tanzu version
/home/linuxbrew/.linuxbrew/bin/tanzu
version: v0.25.0
buildDate: 2022-08-05
sha: 8db7108d
```
